### PR TITLE
Add cgroup package and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 TEST?=./...
 
+.PHONY: test
 test: test_unit test_integration
 
+.PHONY: test_unit
 test_unit:
 	go test $(TEST) --tags=unit
 
+.PHONY: test_integration
 test_integration:
 	go test $(TEST) --tags=integration

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+TEST?=./...
+
+test: test_unit test_integration
+
+test_unit:
+	go test $(TEST) --tags=unit
+
+test_integration:
+	go test $(TEST) --tags=integration

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/bill-rich/rjob
+
+go 1.17
+
+require (
+	github.com/sirupsen/logrus v1.8.1
+	golang.org/x/sys v0.0.0-20211112193437-faf0a1b62c6b
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211112193437-faf0a1b62c6b h1:uo+9AuR+gDt/gdj+1BaLhdOHsaGI6YU6585IiDcLrFE=
+golang.org/x/sys v0.0.0-20211112193437-faf0a1b62c6b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -1,0 +1,180 @@
+package cgroup
+
+import (
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// Set a few constants for simplicity. These could be read from a configuration.
+const (
+	CgroupMountDir = "/tmp/rjob/cgroup"
+	fileMode       = 0660
+)
+
+// CgroupConfig is used to create, delete, and manage a cgroup.
+type CgroupConfig struct {
+	Name string
+
+	Cpu    int
+	Memory int
+	Io     int
+
+	Path string
+}
+
+// Mount will mount the cgroup hierarchy at mountDir.
+func Mount(mountDir string) error {
+	log.Debugf("Mounting cgroup hierarchy at %s", mountDir)
+
+	if err := os.MkdirAll(mountDir, fileMode); err != nil {
+		return fmt.Errorf("error creating cgroup mount directory %s: %s", mountDir, err)
+	}
+
+	if err := unix.Mount("none", mountDir, "cgroup2", 0, ""); err != nil {
+		return fmt.Errorf("error mounting cgroup2 at %s: %s", mountDir, err)
+	}
+
+	log.Debugf("Cgroup hierarchy mounted successfully")
+	return verifyCgroupRequirements()
+}
+
+// Umount unmounts the cgroup hierarchy mounted at mountDir.
+func Umount(mountDir string) error {
+	log.Debugf("Unmounting cgroup hierarchy at %s", mountDir)
+
+	if err := unix.Unmount(mountDir, 0); err != nil {
+		return fmt.Errorf("unable to unmount cgroup fs: %s", err)
+	}
+
+	log.Debugf("Cgroup hierarchy unmounted successfully")
+	return nil
+}
+
+func verifyCgroupRequirements() error {
+	// TODO: Check that required subsystems are enabled, control files exist, etc.
+	return nil
+}
+
+// Create will create the configured cgroup and set the limits for cpu, memory,
+// and io.
+func (cg *CgroupConfig) Create() error {
+	log.Debugf("Creating cgroup %s", cg.Name)
+
+	if err := os.Mkdir(cg.Path, fileMode); err != nil {
+		return fmt.Errorf("error making cgroup directory %s: %s", cg.Path, err)
+	}
+
+	// Set cgroup limits
+	if err := cg.setCpuLimit(); err != nil {
+		return err
+	}
+	if err := cg.setMemoryLimit(); err != nil {
+		return err
+	}
+	if err := cg.setBlkIoLimit(); err != nil {
+		return err
+	}
+
+	log.Debugf("Cgroup %s created successfully", cg.Name)
+	return nil
+}
+
+// Delete will delete the configured cgroup by removing the directory. Processes
+// int the cgroup must be killed or moved before deleting.
+func (cg *CgroupConfig) Delete() error {
+	log.Debugf("Deleting cgroup %s", cg.Name)
+
+	if err := os.Remove(cg.Path); err != nil {
+		return fmt.Errorf("unable to remove cgroup %s: %s", cg.Name, err)
+	}
+	log.Debugf("Cgroup %s deleted successfully", cg.Name)
+
+	return nil
+}
+
+func (cg *CgroupConfig) setCpuLimit() error {
+	cpuFile, err := os.OpenFile(fmt.Sprintf("%s/cpu.max", cg.Path), os.O_APPEND|os.O_WRONLY, fileMode)
+	if err != nil {
+		return fmt.Errorf("error opening %s/cpu.max: %s", cg.Path, err)
+	}
+	defer cpuFile.Close()
+
+	if _, err := cpuFile.WriteString(cg.getCpuMax()); err != nil {
+		return fmt.Errorf("error writing CPU limit to %s/cpu.max: %s", cg.Path, err)
+	}
+
+	return nil
+}
+
+func (cg *CgroupConfig) setMemoryLimit() error {
+	memoryFile, err := os.OpenFile(fmt.Sprintf("%s/memory.max", cg.Path), os.O_APPEND|os.O_WRONLY, fileMode)
+	if err != nil {
+		return fmt.Errorf("error opening %s/memory.max: %s", cg.Path, err)
+	}
+	defer memoryFile.Close()
+
+	// TODO: Change API to accept memory in bytes, or switch both the MB. KB is silly.
+	if _, err := memoryFile.WriteString(cg.getMemMax()); err != nil {
+		return fmt.Errorf("error writing memory limit to %s/memory.max: %s", cg.Path, err)
+	}
+
+	return nil
+}
+
+func (cg *CgroupConfig) setBlkIoLimit() error {
+	ioFile, err := os.OpenFile(fmt.Sprintf("%s/io.weight", cg.Path), os.O_APPEND|os.O_WRONLY, fileMode)
+	if err != nil {
+		return fmt.Errorf("error opening %s/io.weight: %s", cg.Path, err)
+	}
+	defer ioFile.Close()
+
+	if _, err := ioFile.WriteString(cg.getIoWeight()); err != nil {
+		return fmt.Errorf("error writing io limit to %s/io.weight: %s", cg.Path, err)
+	}
+
+	return nil
+}
+
+func (cg *CgroupConfig) getCpuMax() string {
+	switch {
+	case cg.Cpu < 1:
+		log.Infof("Minimum CPU setting is 1, got %d. Setting to 1.", cg.Cpu)
+		cg.Cpu = 1
+	case cg.Cpu > 100:
+		log.Infof("Maximum CPU setting is 100, got %d. Setting to 100.", cg.Cpu)
+		cg.Cpu = 100
+		return "MAX 100000"
+	case cg.Cpu == 100:
+		return "MAX 100000"
+	}
+
+	cpuMax := 100000
+	cpuLimit := float32(cpuMax) * (float32(cg.Cpu) / 100)
+	return fmt.Sprintf("%d %d", int(cpuLimit), cpuMax)
+}
+
+func (cg *CgroupConfig) getMemMax() string {
+	if cg.Memory < 1 {
+		if cg.Memory < 0 {
+			log.Infof("Minimum memory setting is 0 (no limit), got %d. Setting to 0.", cg.Memory)
+			cg.Memory = 0
+		}
+		return "max"
+	}
+	return fmt.Sprintf("%d", cg.Memory*1024)
+}
+
+func (cg *CgroupConfig) getIoWeight() string {
+	switch {
+	case cg.Io < 10:
+		log.Infof("Minimum IO setting is 10, got %d. Setting to 10.", cg.Io)
+		cg.Io = 10
+	case cg.Io > 100:
+		log.Infof("Maximum IO setting is 100, got %d. Setting to 100.", cg.Io)
+		cg.Io = 100
+	}
+	return fmt.Sprintf("%d", cg.Io)
+}

--- a/lib/cgroup/cgroup_integration_test.go
+++ b/lib/cgroup/cgroup_integration_test.go
@@ -1,0 +1,138 @@
+// +build integration
+
+package cgroup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestMountFS checks that the cgroup hierarchy is successfully mounted and
+// unmounted.
+func TestMountFS(t *testing.T) {
+	// Check of cgroup is already mounted
+	mounted, err := testCgroupMounted(CgroupMountDir)
+	if mounted {
+		t.Fatalf("cgroup hierarchy is already mounted at %s", CgroupMountDir)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mount cgroup
+	testMount(CgroupMountDir, t)
+
+	// Unmount cgroup
+	testUnmount(CgroupMountDir, t)
+}
+
+// TestCreateCgroup mounts cgroup hierarchy, creates a new cgroup, verifies the
+// limits are properly set, and cleans up.
+func TestCreateCgroup(t *testing.T) {
+	testMount(CgroupMountDir, t)
+
+	config := CgroupConfig{
+		Name:   "testGroup",
+		Cpu:    90,
+		Memory: 1024,
+		Io:     90,
+		Path:   fmt.Sprintf("%s/%s", CgroupMountDir, "testGroup"),
+	}
+
+	if err := config.Create(); err != nil {
+		t.Error(err)
+	}
+
+	config.testVerifyCgroupSettings(t)
+
+	config.Delete()
+	config.testVerifyCgroupDeleted(t)
+	testUnmount(CgroupMountDir, t)
+
+}
+
+func testMount(path string, t *testing.T) {
+	if err := Mount(CgroupMountDir); err != nil {
+		t.Fatal(err)
+	}
+	mounted, err := testCgroupMounted(CgroupMountDir)
+	if !mounted {
+		t.Fatal("cgroup hierarchy failed to mount")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testUnmount(path string, t *testing.T) {
+	if err := Umount(CgroupMountDir); err != nil {
+		t.Error(err)
+	}
+
+	mounted, err := testCgroupMounted(CgroupMountDir)
+	if mounted {
+		t.Errorf("cgroup hierarchy is still mounted after unmounting")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func (config *CgroupConfig) testVerifyCgroupSettings(t *testing.T) {
+	config.testVerifyCgroupCpuSetting(t)
+}
+
+func (config *CgroupConfig) testVerifyCgroupCpuSetting(t *testing.T) {
+	cpuData, err := os.ReadFile(fmt.Sprintf("%s/cpu.max", config.Path))
+	if err != nil {
+		t.Errorf("unable to read CPU settings: %s", err)
+	}
+	if strings.Compare(strings.TrimSuffix(string(cpuData), "\n"), config.getCpuMax()) != 0 {
+		t.Errorf("cpu.max setting incorrect. expected: %s, got %s", config.getCpuMax(), string(cpuData))
+	}
+}
+
+func (config *CgroupConfig) testVerifyCgroupMemorySetting(t *testing.T) {
+	memData, err := os.ReadFile(fmt.Sprintf("%s/memory.max", config.Path))
+	if err != nil {
+		t.Errorf("unable to read Memory settings: %s", err)
+	}
+	if strings.Compare(strings.TrimSuffix(string(memData), "\n"), config.getMemMax()) != 0 {
+		t.Errorf("memory.max setting incorrect. expected: %s, got %s", config.getMemMax(), string(memData))
+	}
+}
+
+func (config *CgroupConfig) testVerifyCgroupIoSetting(t *testing.T) {
+	ioData, err := os.ReadFile(fmt.Sprintf("%s/io.weight", config.Path))
+	if err != nil {
+		t.Errorf("unable to read IO settings: %s", err)
+	}
+	if strings.Compare(strings.TrimSuffix(string(ioData), "\n"), config.getIoWeight()) != 0 {
+		t.Errorf("io.weight setting incorrect. expected: %s, got %s", config.getIoWeight(), string(ioData))
+	}
+}
+
+func (config *CgroupConfig) testVerifyCgroupDeleted(t *testing.T) {
+	_, err := os.Stat(config.Path)
+	if !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			t.Errorf("cgroup still exists at %s", config.Path)
+		}
+		t.Errorf("error checking if cgroup was deleted: %s", err)
+	}
+}
+
+func testCgroupMounted(path string) (bool, error) {
+	_, err := os.Stat(fmt.Sprintf("%s/cgroup.procs", path))
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, os.ErrNotExist):
+		return false, nil
+	}
+
+	return false, fmt.Errorf("error checking if cgroup hierarchy is mounted: %s", err)
+}

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -6,92 +6,59 @@ import (
 	"testing"
 )
 
-func TestGetCpuMax(t *testing.T) {
-	config := CgroupConfig{
-		Cpu: 50,
+type testCase struct {
+	name           string
+	cgroupConfig   CgroupConfig
+	expectedResult string
+	expectedError  bool
+}
+
+func TestGetCpu(t *testing.T) {
+	testCases := []testCase{
+		{name: "CpuMax", cgroupConfig: CgroupConfig{Cpu: 50}, expectedResult: "50000 100000", expectedError: false},
+		{name: "CpuMax100", cgroupConfig: CgroupConfig{Cpu: 100}, expectedResult: "MAX 100000", expectedError: false},
+		{name: "CpuMaxOverMax", cgroupConfig: CgroupConfig{Cpu: 110}, expectedResult: "", expectedError: true},
+		{name: "CpuMaxUnderMin", cgroupConfig: CgroupConfig{Cpu: 0}, expectedResult: "", expectedError: true},
 	}
-	result := config.getCpuMax()
-	if result != "50000 100000" {
-		t.Errorf("incorrect CPU max value for 50%%. got: %s, expected: 50000 100000", result)
+	for _, tcase := range testCases {
+		result, err := tcase.cgroupConfig.getCpuMax()
+		testCgroupCase(t, tcase, result, err)
 	}
 }
 
-func TestGetCpuMax100(t *testing.T) {
-	config := CgroupConfig{
-		Cpu: 100,
+func TestGetMem(t *testing.T) {
+	testCases := []testCase{
+		{name: "MemMax", cgroupConfig: CgroupConfig{Memory: 2}, expectedResult: "2048", expectedError: false},
+		{name: "MemMaxUnderMin", cgroupConfig: CgroupConfig{Memory: -10}, expectedResult: "", expectedError: true},
 	}
-	result := config.getCpuMax()
-	if result != "MAX 100000" {
-		t.Errorf("incorrect CPU max value for 100%%. got: %s, expected: MAX 100000", result)
-	}
-}
-
-func TestGetCpuMaxOverMax(t *testing.T) {
-	config := CgroupConfig{
-		Cpu: 110,
-	}
-	result := config.getCpuMax()
-	if result != "MAX 100000" {
-		t.Errorf("incorrect CPU over max value for >100(110%%). got: %s, expected: MAX 100000", result)
+	for _, tcase := range testCases {
+		result, err := tcase.cgroupConfig.getMemMax()
+		testCgroupCase(t, tcase, result, err)
 	}
 }
 
-func TestGetCpuMaxUnderMin(t *testing.T) {
-	config := CgroupConfig{
-		Cpu: 0,
+func TestGetIo(t *testing.T) {
+	testCases := []testCase{
+		{name: "IoMax", cgroupConfig: CgroupConfig{Io: 50}, expectedResult: "default 50", expectedError: false},
+		{name: "IoMaxUnderMin", cgroupConfig: CgroupConfig{Io: 9}, expectedResult: "", expectedError: true},
+		{name: "IoMaxOverMax", cgroupConfig: CgroupConfig{Io: 110}, expectedResult: "", expectedError: true},
 	}
-	result := config.getCpuMax()
-	if result != "1000 100000" {
-		t.Errorf("incorrect CPU max value for <1(0%%). got: %s, expected: 1000 100000", result)
-	}
-}
-
-func TestGetIoWeight(t *testing.T) {
-	config := CgroupConfig{
-		Io: 50,
-	}
-	result := config.getIoWeight()
-	if result != "50" {
-		t.Errorf("incorrect IO weight value for 50%%. got: %s, expected: 50", result)
+	for _, tcase := range testCases {
+		result, err := tcase.cgroupConfig.getIoWeight()
+		testCgroupCase(t, tcase, result, err)
 	}
 }
-
-func TestGetIoWeightUnderMin(t *testing.T) {
-	config := CgroupConfig{
-		Io: 9,
+func testCgroupCase(t *testing.T, test testCase, result string, err error) {
+	t.Helper()
+	switch {
+	case test.expectedError && err == nil:
+		t.Errorf("test %s: error expected, but was not received", test.name)
+		return
+	case !test.expectedError && err != nil:
+		t.Errorf("test %s: received error: %s", test.name, err)
+		return
 	}
-	result := config.getIoWeight()
-	if result != "10" {
-		t.Errorf("incorrect IO weight value for <10(9%%). got: %s, expected: 10", result)
-	}
-}
-
-func TestGetIoWeightOverMax(t *testing.T) {
-	config := CgroupConfig{
-		Io: 110,
-	}
-	result := config.getIoWeight()
-	if result != "100" {
-		t.Errorf("incorrect IO weight value for >100(110%%). got: %s, expected: 100", result)
-	}
-}
-
-func TestGetMemMax(t *testing.T) {
-	config := CgroupConfig{
-		Memory: 2,
-	}
-	result := config.getMemMax()
-	if result != "2048" {
-		t.Errorf("incorrect memory max value for 2KB. got: %s, expected: 2048", result)
-	}
-}
-
-func TestGetMemMaxUnderMin(t *testing.T) {
-	config := CgroupConfig{
-		Memory: -10,
-	}
-	result := config.getMemMax()
-	if result != "max" {
-		t.Errorf("incorrect memory max value for <1(-10). got: %s, expected: max", result)
+	if result != test.expectedResult {
+		t.Errorf("test %s: expected: %s, got: %s", test.name, test.expectedResult, result)
 	}
 }

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -1,0 +1,97 @@
+// +build unit
+
+package cgroup
+
+import (
+	"testing"
+)
+
+func TestGetCpuMax(t *testing.T) {
+	config := CgroupConfig{
+		Cpu: 50,
+	}
+	result := config.getCpuMax()
+	if result != "50000 100000" {
+		t.Errorf("incorrect CPU max value for 50%%. got: %s, expected: 50000 100000", result)
+	}
+}
+
+func TestGetCpuMax100(t *testing.T) {
+	config := CgroupConfig{
+		Cpu: 100,
+	}
+	result := config.getCpuMax()
+	if result != "MAX 100000" {
+		t.Errorf("incorrect CPU max value for 100%%. got: %s, expected: MAX 100000", result)
+	}
+}
+
+func TestGetCpuMaxOverMax(t *testing.T) {
+	config := CgroupConfig{
+		Cpu: 110,
+	}
+	result := config.getCpuMax()
+	if result != "MAX 100000" {
+		t.Errorf("incorrect CPU over max value for >100(110%%). got: %s, expected: MAX 100000", result)
+	}
+}
+
+func TestGetCpuMaxUnderMin(t *testing.T) {
+	config := CgroupConfig{
+		Cpu: 0,
+	}
+	result := config.getCpuMax()
+	if result != "1000 100000" {
+		t.Errorf("incorrect CPU max value for <1(0%%). got: %s, expected: 1000 100000", result)
+	}
+}
+
+func TestGetIoWeight(t *testing.T) {
+	config := CgroupConfig{
+		Io: 50,
+	}
+	result := config.getIoWeight()
+	if result != "50" {
+		t.Errorf("incorrect IO weight value for 50%%. got: %s, expected: 50", result)
+	}
+}
+
+func TestGetIoWeightUnderMin(t *testing.T) {
+	config := CgroupConfig{
+		Io: 9,
+	}
+	result := config.getIoWeight()
+	if result != "10" {
+		t.Errorf("incorrect IO weight value for <10(9%%). got: %s, expected: 10", result)
+	}
+}
+
+func TestGetIoWeightOverMax(t *testing.T) {
+	config := CgroupConfig{
+		Io: 110,
+	}
+	result := config.getIoWeight()
+	if result != "100" {
+		t.Errorf("incorrect IO weight value for >100(110%%). got: %s, expected: 100", result)
+	}
+}
+
+func TestGetMemMax(t *testing.T) {
+	config := CgroupConfig{
+		Memory: 2,
+	}
+	result := config.getMemMax()
+	if result != "2048" {
+		t.Errorf("incorrect memory max value for 2KB. got: %s, expected: 2048", result)
+	}
+}
+
+func TestGetMemMaxUnderMin(t *testing.T) {
+	config := CgroupConfig{
+		Memory: -10,
+	}
+	result := config.getMemMax()
+	if result != "max" {
+		t.Errorf("incorrect memory max value for <1(-10). got: %s, expected: max", result)
+	}
+}


### PR DESCRIPTION
The cgroup package manages mounting and unmounting the cgroup hierarchy, creating and deleting cgroups, and managing the CPU, memory, and IO limits for a cgroup.

TODO: Add tests for failure cases.